### PR TITLE
Add SimpleS3Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,25 @@ These simplified clients are as follows:
 
 ### S3
 
+#### SimpleS3Client
+The main entrypoint for working with S3 should be the `SimpleS3Client`.
+It contains all of the subsequent clients inside of it, for you to access as-needed.
+For modularity and separation of concerns, we've separated out the client types based on use-case, but if you need access to everything at once, this is the client you want.
+
+```scala
+import com.rewardsnetwork.pureaws.SimpleS3Client
+
+val s3ClientResource: Resource[IO, SimpleS3Client[IO]] = Blocker[IO].flatMap(SimpleS3Client.async[IO](_, region))
+
+s3ClientResource.use { client =>
+  ///Access each of the clients within here
+}
+```
+
+Detailed below are each of these clients and their individual use-cases.
+
 #### S3ObjectOps
-Perform basic operations on S3 objects:
+Perform basic operations on S3 objects, available at `SimpleS3Client#ops` or by itself:
 
 ```scala
 import com.rewardsnetwork.pureaws.S3ObjectOps
@@ -92,7 +109,7 @@ opsResource.use { ops =>
 ```
 
 #### Sink
-Write S3 objects using S3 (multipart not currently supported):
+Write S3 objects using S3 (multipart not currently supported), available at `SimpleS3Client#sink` or by itself:
 
 ```scala
 import com.rewardsnetwork.pureaws.S3Sink
@@ -109,7 +126,7 @@ sinkResource.use { sink =>
 ```
 
 #### Source
-Stream S3 objects from S3 as bytes:
+Stream S3 objects from S3 as bytes, available at `SimpleS3Client#source` or by itself:
 
 ```scala
 import com.rewardsnetwork.pureaws.S3Source

--- a/modules/s3-testing/src/main/scala/com/rewardsnetwork/pureaws/s3/testing/TestSimpleS3Client.scala
+++ b/modules/s3-testing/src/main/scala/com/rewardsnetwork/pureaws/s3/testing/TestSimpleS3Client.scala
@@ -1,0 +1,22 @@
+package com.rewardsnetwork.pureaws.s3.testing
+
+import cats.effect._
+
+/** An amalgamation of all available S3 algebras in one client. */
+sealed trait TestSimpleS3Client[F[_]] {
+  def ops: TestS3ObjectOps[F]
+  def sink: TestS3Sink[F]
+  def source: TestS3Source[F]
+}
+
+object TestSimpleS3Client {
+
+  /** Constructs a `SimpleS3Client` using an existing `PureS3Client` for some `F[_]`.
+    * Gives you access to all available algebras for the S3 client in one place.
+    */
+  def apply[F[_]: Sync](backend: S3TestingBackend[F]) = new TestSimpleS3Client[F] {
+    val ops = new TestS3ObjectOps(backend)
+    val sink = new TestS3Sink(backend)
+    val source = new TestS3Source(backend)
+  }
+}

--- a/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/SimpleS3Client.scala
+++ b/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/SimpleS3Client.scala
@@ -1,0 +1,42 @@
+package com.rewardsnetwork.pureaws.s3
+
+import cats.effect._
+import cats.MonadError
+import software.amazon.awssdk.regions.Region
+
+/** An amalgamation of all available S3 algebras in one client. */
+sealed trait SimpleS3Client[F[_]] {
+  def ops: S3ObjectOps[F]
+  def sink: S3Sink[F]
+  def source: S3Source[F]
+}
+
+object SimpleS3Client {
+
+  /** Constructs a `SimpleS3Client` using an existing `PureS3Client` for some `F[_]`.
+    * Gives you access to all available algebras for the S3 client in one place.
+    */
+  def apply[F[_]](client: PureS3Client[F])(implicit F: MonadError[F, Throwable]) = new SimpleS3Client[F] {
+    val ops = S3ObjectOps(client)
+    val sink = S3Sink(client)
+    val source = S3Source(client)
+  }
+
+  /** Constructs a `SimpleS3Client` using an underlying synchronous client backend.
+    *
+    * @param blocker A Cats Effect `Blocker`.
+    * @param awsRegion The AWS region you are operating in.
+    * @return A `SimpleS3Client` instance using a synchronous backend.
+    */
+  def sync[F[_]: Sync: ContextShift](blocker: Blocker, awsRegion: Region) =
+    PureS3Client.sync[F](blocker, awsRegion).map(apply[F])
+
+  /** Constructs a `SimpleS3Client` using an underlying asynchronous client backend.
+    *
+    * @param blocker A Cats Effect `Blocker`.
+    * @param awsRegion The AWS region you are operating in.
+    * @return A `SimpleS3Client` instance using an asynchronous backend.
+    */
+  def async[F[_]: Async: ContextShift](blocker: Blocker, awsRegion: Region) =
+    PureS3Client.async[F](blocker, awsRegion).map(apply[F])
+}


### PR DESCRIPTION
One of the things I realized wasn't great about the S3 API is that you have different algebras for different use cases and had to manually create a bunch of them if you wanted them all. This adds `SimpleS3Client` which combines all the existing algebras under one roof, but still leaves them as modular if you happen to want that.