### PR TITLE
S3 Bucket/Object Ops Enhancements

### DIFF
--- a/modules/s3-testing/src/main/scala/com/rewardsnetwork/pureaws/s3/testing/S3TestingBackend.scala
+++ b/modules/s3-testing/src/main/scala/com/rewardsnetwork/pureaws/s3/testing/S3TestingBackend.scala
@@ -1,37 +1,109 @@
 package com.rewardsnetwork.pureaws.s3.testing
 
+import java.time.Instant
+
+import cats.data.OptionT
 import cats.effect.Sync
 import cats.effect.concurrent.Ref
 import cats.implicits._
+import internal.newInstant
+import S3TestingBackend._
 
 /** Defines a basic backend implementation for testing S3 interface usage */
 trait S3TestingBackend[F[_]] {
 
   /** If the payload exists, get it and its metadata as a `Map`. */
-  def get(bucket: String, key: String): F[Option[(Map[String, String], Array[Byte])]]
-  def delete(bucket: String, key: String): F[Unit]
+  def get(bucket: String, key: String): F[Option[(Metadata, Payload)]]
+
+  /** Delete a bucket and all of its objects. */
+  def deleteBucket(bucket: String): F[Unit]
+
+  /** Delete an object from a bucket, if it exists. */
+  def deleteObject(bucket: String, key: String): F[Unit]
+
+  /** Create a new bucket. Not required if `autoCreateBuckets` is enabled. Spe */
+  def newBucket(bucket: String, createdAt: Option[Instant] = none): F[Unit]
+
+  /** Put an object in a particular bucket with configured metadata. */
   def put(bucket: String, key: String, payload: Array[Byte], metadata: Map[String, String] = Map.empty): F[Unit]
 
-  /** Key of map is (bucket, key), results are (metadata, payload) */
-  def getAll: F[Map[(String, String), (Map[String, String], Array[Byte])]]
+  /** Map of all buckets, containing a map of all keys in that bucket to associated metadata and payload information. */
+  def getAll: F[BucketMap]
 }
 
 object S3TestingBackend {
 
-  /** An S3 testing backend that runs in-memory using a concurrently available Map. */
-  def inMemory[F[_]: Sync] =
-    Ref[F].of(Map.empty[(String, String), (Map[String, String], Array[Byte])]).map { ref =>
-      new S3TestingBackend[F] {
-        def get(bucket: String, key: String): F[Option[(Map[String, String], Array[Byte])]] =
-          ref.get.map(_.get(bucket -> key))
+  type Metadata = Map[String, String]
+  type Payload = Array[Byte]
+  type ObjectMap = Map[String, (Metadata, Payload)]
+  type BucketMap = Map[String, (Instant, ObjectMap)]
 
-        def delete(bucket: String, key: String): F[Unit] =
-          ref.update(_ - (bucket -> key))
+  /** An in-memory fake S3 backend.
+    *
+    * @param autoCreateBuckets Whether or not to automatically assume there is a bucket for each new object uploaded. Defaults to `true`.
+    * @return An `F[S3TestingBackend]` for plugging into other test utilities in the S3 Testing module.
+    */
+  def inMemory[F[_]: Sync](autoCreateBuckets: Boolean = true) =
+    Ref[F].of[BucketMap](Map.empty).map { ref =>
+      new S3TestingBackend[F] {
+        private def getBucketObjects(bucket: String): F[Option[ObjectMap]] =
+          ref.get.map(_.get(bucket).map(_._2))
+
+        def get(bucket: String, key: String): F[Option[(Metadata, Payload)]] =
+          OptionT(getBucketObjects(bucket)).flatMap(om => OptionT.fromOption(om.get(key))).value
+
+        def deleteBucket(bucket: String): F[Unit] = ref.modify { buckets =>
+          buckets.get(bucket) match {
+            case None    => buckets -> Sync[F].raiseError[Unit](new Exception(s"Bucket $bucket does not exist"))
+            case Some(_) => buckets - bucket -> Sync[F].unit
+          }
+        }.flatten
+
+        def deleteObject(bucket: String, key: String): F[Unit] = ref.modify { buckets =>
+          buckets.get(bucket) match {
+            case None =>
+              buckets -> Sync[F].raiseError[Unit](new Exception(s"Object $key does not exist in bucket $bucket"))
+            case Some((instant, b)) =>
+              b.get(key) match {
+                case None =>
+                  buckets -> Sync[F].raiseError[Unit](new Exception(s"Object $key does not exist in bucket $bucket"))
+                case Some(_) =>
+                  val newBuckets = buckets + (bucket -> (instant -> (b - key)))
+                  newBuckets -> Sync[F].unit
+              }
+          }
+        }.flatten
+
+        def newBucket(bucket: String, createdAt: Option[Instant] = none): F[Unit] = {
+          val getCreatedAt = OptionT.fromOption[F](createdAt).getOrElseF(newInstant[F])
+
+          getCreatedAt.flatMap { instant =>
+            ref.modify { buckets =>
+              buckets.get(bucket) match {
+                case Some(_) => buckets -> Sync[F].raiseError[Unit](new Exception(s"Bucket $bucket already exists"))
+                case None =>
+                  buckets + (bucket -> (instant -> Map
+                    .empty[String, (Map[String, String], Array[Byte])])) -> Sync[F].unit
+              }
+            }.flatten
+          }
+        }
 
         def put(bucket: String, key: String, payload: Array[Byte], metadata: Map[String, String] = Map.empty): F[Unit] =
-          ref.update(_ + ((bucket -> key) -> (metadata -> payload)))
+          newInstant[F].flatMap { instant =>
+            ref.modify { buckets =>
+              buckets.get(bucket) match {
+                case None if (autoCreateBuckets) =>
+                  buckets + (bucket -> (instant -> Map(key -> (metadata -> payload)))) -> Sync[F].unit
+                case None => buckets -> Sync[F].raiseError[Unit](new Exception(s"Bucket $bucket does not exist"))
+                case Some((instant, b)) =>
+                  val newBuckets = buckets + (bucket -> (instant -> (b + (key -> (metadata -> payload)))))
+                  newBuckets -> Sync[F].unit
+              }
+            }.flatten
+          }
 
-        def getAll: F[Map[(String, String), (Map[String, String], Array[Byte])]] = ref.get
+        def getAll: F[BucketMap] = ref.get
       }
     }
 }

--- a/modules/s3-testing/src/main/scala/com/rewardsnetwork/pureaws/s3/testing/TestS3BucketOps.scala
+++ b/modules/s3-testing/src/main/scala/com/rewardsnetwork/pureaws/s3/testing/TestS3BucketOps.scala
@@ -1,0 +1,42 @@
+package com.rewardsnetwork.pureaws.s3.testing
+
+import cats._
+import cats.implicits._
+import com.rewardsnetwork.pureaws.s3.{S3BucketPermission, S3BucketOps}
+import software.amazon.awssdk.services.s3.model._
+import com.rewardsnetwork.pureaws.s3.S3BucketInfo
+
+/** A test utility for integrating with the `S3BucketOps` algebra.
+  *
+  * @param backend Your `S3TestingBackend`.
+  * @param failWith An optional `Throwable` that you would like all requests to fail with, to test error recovery.
+  */
+class TestS3BucketOps[F[_]](backend: S3TestingBackend[F], failWith: Option[Throwable] = none)(implicit
+    F: MonadError[F, Throwable]
+) extends S3BucketOps[F] {
+
+  private def doOrFail[A](fa: F[A]): F[A] = failWith match {
+    case Some(t) => F.raiseError(t)
+    case None    => fa
+  }
+
+  /** All parameters except for `name` are ignored. */
+  def createBucket(
+      name: String,
+      location: BucketLocationConstraint,
+      acl: BucketCannedACL,
+      permissions: List[(String, S3BucketPermission)] = Nil
+  ): F[Unit] = doOrFail(backend.newBucket(name))
+
+  /** `expectedBucketOwner` is ignored. */
+  def deleteBucket(name: String, expectedBucketOwner: Option[String] = none): F[Unit] = doOrFail {
+    backend.deleteBucket(name)
+  }
+
+  def listBuckets: F[List[S3BucketInfo]] = doOrFail {
+    backend.getAll.map(_.toList.map { case (name, (createdAt, _)) =>
+      S3BucketInfo(name, createdAt)
+    })
+  }
+
+}

--- a/modules/s3-testing/src/main/scala/com/rewardsnetwork/pureaws/s3/testing/TestS3ObjectOps.scala
+++ b/modules/s3-testing/src/main/scala/com/rewardsnetwork/pureaws/s3/testing/TestS3ObjectOps.scala
@@ -55,9 +55,11 @@ class TestS3ObjectOps[F[_]](backend: S3TestingBackend[F], failWith: Option[Throw
       bm.get(bucket) match {
         case None => Stream.raiseError[F](new Exception(s"Bucket $bucket does not exist"))
         case Some((_, objects)) =>
-          val allObjs = objects.toList.map { case (key, (_, payload)) =>
-            S3ObjectInfo(bucket, key, Instant.EPOCH, "", "", "", payload.length.toLong)
-          }
+          val allObjs = objects.toList
+            .map { case (key, (_, payload)) =>
+              S3ObjectInfo(bucket, key, Instant.EPOCH, "", "", "", payload.length.toLong)
+            }
+            .sortBy(_.key)
 
           val pages = allObjs.sliding(maxKeysPerRequest).toList
 

--- a/modules/s3-testing/src/main/scala/com/rewardsnetwork/pureaws/s3/testing/TestS3ObjectOps.scala
+++ b/modules/s3-testing/src/main/scala/com/rewardsnetwork/pureaws/s3/testing/TestS3ObjectOps.scala
@@ -46,10 +46,10 @@ class TestS3ObjectOps[F[_]](backend: S3TestingBackend[F], failWith: Option[Throw
   def listObjectsPaginated(
       bucket: String,
       maxKeysPerRequest: Int,
-      delimiter: Option[String],
-      prefix: Option[String],
-      expectedBucketOwner: Option[String],
-      requestPayer: Option[RequestPayer]
+      delimiter: Option[String] = none,
+      prefix: Option[String] = none,
+      expectedBucketOwner: Option[String] = none,
+      requestPayer: Option[RequestPayer] = none
   ): fs2.Stream[F, S3ObjectListing] = doOrFailStream {
     Stream.eval(backend.getAll).flatMap { bm =>
       bm.get(bucket) match {
@@ -99,10 +99,10 @@ class TestS3ObjectOps[F[_]](backend: S3TestingBackend[F], failWith: Option[Throw
     */
   def listObjects(
       bucket: String,
-      delimiter: Option[String],
-      prefix: Option[String],
-      expectedBucketOwner: Option[String],
-      requestPayer: Option[RequestPayer]
+      delimiter: Option[String] = none,
+      prefix: Option[String] = none,
+      expectedBucketOwner: Option[String] = none,
+      requestPayer: Option[RequestPayer] = none
   )(implicit sync: Sync[F]): F[S3ObjectListing] = listObjectsPaginated(
     bucket = bucket,
     delimiter = delimiter,

--- a/modules/s3-testing/src/main/scala/com/rewardsnetwork/pureaws/s3/testing/TestS3ObjectOps.scala
+++ b/modules/s3-testing/src/main/scala/com/rewardsnetwork/pureaws/s3/testing/TestS3ObjectOps.scala
@@ -61,7 +61,7 @@ class TestS3ObjectOps[F[_]](backend: S3TestingBackend[F], failWith: Option[Throw
             }
             .sortBy(_.key)
 
-          val pages = allObjs.sliding(maxKeysPerRequest).toList
+          val pages = allObjs.sliding(maxKeysPerRequest, maxKeysPerRequest).toList
 
           Stream.emits(pages).map { objs =>
             val resultsForDelimitedPrefix: Option[(List[S3ObjectInfo], Set[String])] = for {

--- a/modules/s3-testing/src/main/scala/com/rewardsnetwork/pureaws/s3/testing/TestS3ObjectOps.scala
+++ b/modules/s3-testing/src/main/scala/com/rewardsnetwork/pureaws/s3/testing/TestS3ObjectOps.scala
@@ -3,6 +3,10 @@ package com.rewardsnetwork.pureaws.s3.testing
 import cats._
 import cats.implicits._
 import com.rewardsnetwork.pureaws.s3.S3ObjectOps
+import com.rewardsnetwork.pureaws.s3.S3ObjectInfo
+import software.amazon.awssdk.services.s3.model.RequestPayer
+import java.time.Instant
+import com.rewardsnetwork.pureaws.s3.S3ObjectListing
 
 /** A test utility for integrating with the `S3ObjectOps` algebra.
   *
@@ -18,19 +22,49 @@ class TestS3ObjectOps[F[_]](backend: S3TestingBackend[F], failWith: Option[Throw
     case None    => fa
   }
 
-  def copy(oldBucket: String, oldKey: String, newBucket: String, newKey: String): F[Unit] = doOrFail {
+  def copyObject(oldBucket: String, oldKey: String, newBucket: String, newKey: String): F[Unit] = doOrFail {
     backend.get(oldBucket, oldKey).flatMap {
       case None              => F.raiseError(new Exception("Object not found"))
       case Some((meta, obj)) => backend.put(newBucket, newKey, obj, meta)
     }
   }
 
-  def delete(bucket: String, key: String): F[Unit] = doOrFail {
-    backend.delete(bucket, key)
+  def deleteObject(bucket: String, key: String): F[Unit] = doOrFail {
+    backend.deleteObject(bucket, key)
   }
 
-  def move(oldBucket: String, oldKey: String, newBucket: String, newKey: String): F[Unit] = doOrFail {
-    copy(oldBucket, oldKey, newBucket, newKey) >> delete(oldBucket, oldKey)
+  def moveObject(oldBucket: String, oldKey: String, newBucket: String, newKey: String): F[Unit] = doOrFail {
+    copyObject(oldBucket, oldKey, newBucket, newKey) >> deleteObject(oldBucket, oldKey)
+  }
+
+  /** `expectedBucketOwner` and `requestPayer` are ignored.
+    * All object parameters besides bucket and key are faked and should not be relied upon.
+    * The list of common
+    */
+  def listObjects(
+      bucket: String,
+      delimiter: Option[String],
+      prefix: Option[String],
+      expectedBucketOwner: Option[String],
+      requestPayer: Option[RequestPayer]
+  ): F[S3ObjectListing] = doOrFail {
+    backend.getAll.flatMap { bm =>
+      bm.get(bucket) match {
+        case None => F.raiseError(new Exception(s"Bucket $bucket does not exist"))
+        case Some((_, objects)) =>
+          val objs = objects.toList.map { case (key, _) =>
+            S3ObjectInfo(bucket, key, Instant.EPOCH, "", "", "")
+          }
+          val maybePrefixes = for {
+            d <- delimiter
+            p <- prefix
+          } yield {
+            objs.map(_.key.stripPrefix(p).split(d).dropRight(1).mkString).distinct.map(p + _)
+          }
+
+          S3ObjectListing(objs, maybePrefixes.getOrElse(Nil)).pure[F]
+      }
+    }
   }
 
 }

--- a/modules/s3-testing/src/main/scala/com/rewardsnetwork/pureaws/s3/testing/internal.scala
+++ b/modules/s3-testing/src/main/scala/com/rewardsnetwork/pureaws/s3/testing/internal.scala
@@ -1,0 +1,8 @@
+package com.rewardsnetwork.pureaws.s3.testing
+
+import java.time.Instant
+import cats.effect.Sync
+
+object internal {
+  def newInstant[F[_]: Sync]: F[Instant] = Sync[F].delay(Instant.now())
+}

--- a/modules/s3-testing/src/test/scala/com/rewardsnetwork/pureaws/s3/testing/TestS3ObjectOpsSpec.scala
+++ b/modules/s3-testing/src/test/scala/com/rewardsnetwork/pureaws/s3/testing/TestS3ObjectOpsSpec.scala
@@ -1,0 +1,68 @@
+package com.rewardsnetwork.pureaws.s3.testing
+
+import cats.effect.IO
+import cats.syntax.all._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.scalacheck.Gen
+import com.rewardsnetwork.pureaws.s3.S3ObjectInfo
+import java.time.Instant
+import com.rewardsnetwork.pureaws.s3.S3ObjectListing
+import cats.Traverse
+
+class TestS3ObjectOpsSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks {
+
+  "TestS3ObjectOps" - {
+    "listObjectsPaginated" - {
+      "should paginate objects and common prefixes" in {
+        forAll(Gen.alphaStr, Gen.alphaStr, Gen.alphaStr) { (preFirst, preSecond, preThird) =>
+          //Ensure the inputs for prefixes are non-empty
+          val (first, second, third) = (s"first-$preFirst", s"second-$preSecond", s"third-$preThird")
+
+          val bucket = "test-bucket"
+          val program = S3TestingBackend.inMemory[IO]().flatMap { backend =>
+            val objOps = new TestS3ObjectOps(backend)
+            val objIds = (0 to 100).toList
+            val prepS3 = objIds.traverse { i =>
+              backend.put(bucket, s"$first/$second/$third/$i.txt", Array.emptyByteArray)
+            }
+
+            //Should return all objects 0 to 100 as the prefix is exactly the same common prefix
+            val listPaginated =
+              objOps.listObjectsPaginated(bucket, 10, "/".some, s"$first/$second/$third/".some).compile.toList
+
+            //A prefix of only the first two dirs is not a "common prefix", so results are empty
+            //It should still return common prefixes starting with this string, but no objects.
+            val listPaginatedEmpty =
+              objOps.listObjectsPaginated(bucket, 10, "/".some, s"$first/$second/".some).compile.toList
+
+            //Normal results should have up to 10 objects (101 in total) and share the same common prefix
+            val expectedResults = objIds
+              .sortBy(i => s"$first/$second/$third/$i.txt")
+              .map { i =>
+                val info = S3ObjectInfo(bucket, s"$first/$second/$third/$i.txt", Instant.EPOCH, "", "", "", 0L)
+                S3ObjectListing(List(info), Set(s"$first/$second/$third/"))
+              }
+              .sliding(10, 10)
+              .map(Traverse[List].fold(_))
+              .toList
+
+            //Should be 11 instances of the same prefix with no objects
+            val expectedEmptyResults = List.fill(11)(S3ObjectListing(Nil, Set(s"$first/$second/$third/")))
+
+            val results = prepS3 >> listPaginated.product(listPaginatedEmpty)
+
+            results.flatMap { case (mainResults, emptyResults) =>
+              val mainAssertion = IO(mainResults shouldBe expectedResults)
+              val emptyAssertion = IO(emptyResults shouldBe expectedEmptyResults)
+              mainAssertion >> emptyAssertion
+            }
+          }
+
+          program.unsafeRunSync()
+        }
+      }
+    }
+  }
+}

--- a/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/PureS3Client.scala
+++ b/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/PureS3Client.scala
@@ -34,6 +34,33 @@ trait PureS3Client[F[_]] {
     */
   def completeMultipartUpload(r: CompleteMultipartUploadRequest): F[CompleteMultipartUploadResponse]
 
+  /** Create an S3 bucket with the provided configuration.
+    *
+    * @param r A `CreateBucketRequest` containing the name and permissions of the bucket you would like to create.
+    * @return A `CreateBucketResponse` indicating the status of your request.
+    */
+  def createBucket(r: CreateBucketRequest): F[CreateBucketResponse]
+
+  /** Delete an S3 bucket.
+    *
+    * @param r A `DeleteBucketRequest` containing the name of the bucket you would like to delete.
+    * @return A `DeleteBucketResponse` indicating the status of your request.
+    */
+  def deleteBucket(r: DeleteBucketRequest): F[DeleteBucketResponse]
+
+  /** Lists all available S3 buckets.
+    *
+    * @return A `ListBucketsResponse` containing a list of all available buckets.
+    */
+  def listBuckets(): F[ListBucketsResponse]
+
+  /** Checks if you have permissions to access a given bucket.
+    *
+    * @param r A `HeadBucketRequest` containing information about the bucket you would like to check your permissions for.
+    * @return A `HeadBucketResponse` indicating the status of your request.
+    */
+  def headBucket(r: HeadBucketRequest): F[HeadBucketResponse]
+
   /** Signal the intent to start a multipart upload.
     *
     * @param r A `CreateMultipartUploadRequest` with the bucket, key, and other parameters for your object.
@@ -83,6 +110,13 @@ trait PureS3Client[F[_]] {
     * @return A `DeleteObjectRequest` indicating the status of your request.
     */
   def deleteObject(r: DeleteObjectRequest): F[DeleteObjectResponse]
+
+  /** Lists all available objects in an S3 bucket.
+    *
+    * @param r A `ListObjectsV2Request` containing the name of the bucket you would like to list objects in.
+    * @return A `ListObjectsResponse` indicating the status of your request.
+    */
+  def listObjects(r: ListObjectsV2Request): F[ListObjectsV2Response]
 }
 
 object PureS3Client {
@@ -131,6 +165,21 @@ object PureS3Client {
       def deleteObject(r: DeleteObjectRequest): F[DeleteObjectResponse] =
         block(client.deleteObject(r))
 
+      def createBucket(r: CreateBucketRequest): F[CreateBucketResponse] =
+        block(client.createBucket(r))
+
+      def deleteBucket(r: DeleteBucketRequest): F[DeleteBucketResponse] =
+        block(client.deleteBucket(r))
+
+      def listBuckets(): F[ListBucketsResponse] =
+        block(client.listBuckets())
+
+      def headBucket(r: HeadBucketRequest): F[HeadBucketResponse] =
+        block(client.headBucket(r))
+
+      def listObjects(r: ListObjectsV2Request): F[ListObjectsV2Response] =
+        block(client.listObjectsV2(r))
+
     }
 
   /** Builds a `PureS3Client` from an AWS SDK `S3AsyncClient`.
@@ -177,6 +226,21 @@ object PureS3Client {
 
       def deleteObject(r: DeleteObjectRequest): F[DeleteObjectResponse] =
         lift(client.deleteObject(r))
+
+      def createBucket(r: CreateBucketRequest): F[CreateBucketResponse] =
+        lift(client.createBucket(r))
+
+      def deleteBucket(r: DeleteBucketRequest): F[DeleteBucketResponse] =
+        lift(client.deleteBucket(r))
+
+      def listBuckets(): F[ListBucketsResponse] =
+        lift(client.listBuckets())
+
+      def headBucket(r: HeadBucketRequest): F[HeadBucketResponse] =
+        lift(client.headBucket(r))
+
+      def listObjects(r: ListObjectsV2Request): F[ListObjectsV2Response] =
+        lift(client.listObjectsV2(r))
 
     }
 

--- a/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3BucketInfo.scala
+++ b/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3BucketInfo.scala
@@ -1,0 +1,5 @@
+package com.rewardsnetwork.pureaws.s3
+
+import java.time.Instant
+
+final case class S3BucketInfo(name: String, createdAt: Instant)

--- a/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3BucketOps.scala
+++ b/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3BucketOps.scala
@@ -48,7 +48,7 @@ object S3BucketOps {
         permissions: List[(String, S3BucketPermission)] = Nil
     ): F[Unit] = {
       val bucketConfig = CreateBucketConfiguration.builder.locationConstraint(location).build
-      val initialReq = CreateBucketRequest.builder.bucket(name).createBucketConfiguration(bucketConfig)
+      val initialReq = CreateBucketRequest.builder.bucket(name).acl(acl).createBucketConfiguration(bucketConfig)
       val finalReq = permissions
         .foldRight(initialReq) { case ((name, permissions), req) =>
           permissions match {

--- a/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3BucketOps.scala
+++ b/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3BucketOps.scala
@@ -1,0 +1,81 @@
+package com.rewardsnetwork.pureaws.s3
+
+import cats.Functor
+import cats.implicits._
+import com.rewardsnetwork.pureaws.s3.S3BucketPermission._
+import software.amazon.awssdk.services.s3.model._
+
+import scala.jdk.CollectionConverters._
+
+trait S3BucketOps[F[_]] {
+
+  /** Create an S3 bucket with the given parameters.
+    *
+    * @param name The name of the bucket.
+    * @param location The AWS region (as a `BucketLocationConstraint`) that the bucket should be created in.
+    * @param acl The Access Control List for this bucket.
+    * @param permissions Pairs of grantees and their S3BucketPermissions. Optional.
+    * @return `Unit` if successful, will throw if failed.
+    */
+  def createBucket(
+      name: String,
+      location: BucketLocationConstraint,
+      acl: BucketCannedACL,
+      permissions: List[(String, S3BucketPermission)] = Nil
+  ): F[Unit]
+
+  /** Delete an S3 bucket with the given parameters.
+    *
+    * @param name The name of the bucket.
+    * @param expectedBucketOwner The expected owner of the bucket, if needed.
+    * @return `Unit` if successful, will throw if failed.
+    */
+  def deleteBucket(name: String, expectedBucketOwner: Option[String] = none): F[Unit]
+
+  /** Returns a list of available S3 buckets.
+    *
+    * @return A list of buckets indicating what buckets you have access to and when they were created.
+    */
+  def listBuckets: F[List[S3BucketInfo]]
+}
+
+object S3BucketOps {
+  def apply[F[_]: Functor](client: PureS3Client[F]): S3BucketOps[F] = new S3BucketOps[F] {
+    def createBucket(
+        name: String,
+        location: BucketLocationConstraint,
+        acl: BucketCannedACL,
+        permissions: List[(String, S3BucketPermission)] = Nil
+    ): F[Unit] = {
+      val bucketConfig = CreateBucketConfiguration.builder.locationConstraint(location).build
+      val initialReq = CreateBucketRequest.builder.bucket(name).createBucketConfiguration(bucketConfig)
+      val finalReq = permissions
+        .foldRight(initialReq) { case ((name, permissions), req) =>
+          permissions match {
+            case Read        => req.grantRead(name)
+            case ReadACL     => req.grantReadACP(name)
+            case Write       => req.grantWrite(name)
+            case WriteACL    => req.grantWriteACP(name)
+            case FullControl => req.grantFullControl(name)
+          }
+        }
+        .build
+
+      client.createBucket(finalReq).void
+    }
+
+    def deleteBucket(name: String, expectedBucketOwner: Option[String] = none): F[Unit] = {
+      val initialReq = DeleteBucketRequest.builder.bucket(name)
+      val finalReq = expectedBucketOwner.fold(initialReq)(initialReq.expectedBucketOwner).build
+
+      client.deleteBucket(finalReq).void
+    }
+
+    def listBuckets: F[List[S3BucketInfo]] =
+      client
+        .listBuckets()
+        .map(_.buckets.asScala.toList)
+        .map(_.map(bucket => S3BucketInfo(bucket.name, bucket.creationDate)))
+
+  }
+}

--- a/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3BucketPermission.scala
+++ b/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3BucketPermission.scala
@@ -1,0 +1,22 @@
+package com.rewardsnetwork.pureaws.s3
+
+/** A type of permission that may be granted for an S3 bucket. */
+sealed trait S3BucketPermission extends Product with Serializable
+
+object S3BucketPermission {
+
+  /** Permission to read objects in this bucket. */
+  case object Read extends S3BucketPermission
+
+  /** Permission to read the ACL of this bucket. */
+  case object ReadACL extends S3BucketPermission
+
+  /** Permission to write objects to this bucket. */
+  case object Write extends S3BucketPermission
+
+  /** Permissions to modify the ACL of this bucket. */
+  case object WriteACL extends S3BucketPermission
+
+  /** Permissions to read/write objects and the ACL of this bucket. */
+  case object FullControl extends S3BucketPermission
+}

--- a/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3ObjectInfo.scala
+++ b/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3ObjectInfo.scala
@@ -1,0 +1,19 @@
+package com.rewardsnetwork.pureaws.s3
+
+import java.time.Instant
+
+import software.amazon.awssdk.services.s3.model.S3Object
+
+final case class S3ObjectInfo(
+    bucket: String,
+    key: String,
+    lastModified: Instant,
+    eTag: String,
+    ownerDisplayName: String,
+    ownerId: String
+)
+
+object S3ObjectInfo {
+  def fromObject(o: S3Object, bucket: String) =
+    S3ObjectInfo(bucket, o.key, o.lastModified, o.eTag, o.owner.displayName, o.owner.id)
+}

--- a/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3ObjectInfo.scala
+++ b/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3ObjectInfo.scala
@@ -4,16 +4,33 @@ import java.time.Instant
 
 import software.amazon.awssdk.services.s3.model.S3Object
 
+/** Information about an S3 object from a request to list objects.
+  *
+  * @param bucket The bucket the object was found in.
+  * @param key The key of the object.
+  * @param lastModified The `java.time.Instant` that this object was last modified.
+  * @param eTag The `ETag`, or unique identifier, of this object.
+  * @param ownerDisplayName The display name of the owner.
+  * @param ownerId The ID of the owner.
+  * @param sizeBytes The size of the object in bytes.
+  */
 final case class S3ObjectInfo(
     bucket: String,
     key: String,
     lastModified: Instant,
     eTag: String,
     ownerDisplayName: String,
-    ownerId: String
+    ownerId: String,
+    sizeBytes: Long
 )
 
 object S3ObjectInfo {
-  def fromObject(o: S3Object, bucket: String) =
-    S3ObjectInfo(bucket, o.key, o.lastModified, o.eTag, o.owner.displayName, o.owner.id)
+
+  /** Turn an `S3Object` into an `S3ObjectInfo` given the bucket it came from.
+    *
+    * @param o The `S3Object` you are turning into an `S3ObjectInfo`.
+    * @param bucket The bucket that the object came from.
+    */
+  def fromS3Object(o: S3Object, bucket: String) =
+    S3ObjectInfo(bucket, o.key, o.lastModified, o.eTag, o.owner.displayName, o.owner.id, o.size)
 }

--- a/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3ObjectListing.scala
+++ b/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3ObjectListing.scala
@@ -4,4 +4,4 @@ package com.rewardsnetwork.pureaws.s3
   * A "common prefix" in this case is any delimited part of an S3 object key that has no data, and acts like a directory.
   * For example if you have a key `foo/bar/baz` then `foo/bar` would be a common prefix, as there is no data at that key.
   */
-final case class S3ObjectListing(objects: List[S3ObjectInfo], commonPrefixes: List[String])
+final case class S3ObjectListing(objects: List[S3ObjectInfo], commonPrefixes: Set[String])

--- a/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3ObjectListing.scala
+++ b/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3ObjectListing.scala
@@ -1,7 +1,25 @@
 package com.rewardsnetwork.pureaws.s3
 
+import cats.kernel.Monoid
+
 /** A listing of S3 objects and all common prefixes between them.
   * A "common prefix" in this case is any delimited part of an S3 object key that has no data, and acts like a directory.
   * For example if you have a key `foo/bar/baz` then `foo/bar` would be a common prefix, as there is no data at that key.
+  *
+  * There is also a `Monoid` instance for this type, or you can combine listings using the `++` operator.
   */
-final case class S3ObjectListing(objects: List[S3ObjectInfo], commonPrefixes: Set[String])
+final case class S3ObjectListing(objects: List[S3ObjectInfo], commonPrefixes: Set[String]) {
+
+  /** Combine all S3 objects and prefixes from a paginated request together into one larger listing. */
+  def ++(ol: S3ObjectListing) = copy(
+    objects = objects ++ ol.objects,
+    commonPrefixes = commonPrefixes ++ ol.commonPrefixes
+  )
+}
+
+object S3ObjectListing {
+  implicit val monoid: Monoid[S3ObjectListing] = new Monoid[S3ObjectListing] {
+    def combine(x: S3ObjectListing, y: S3ObjectListing): S3ObjectListing = x ++ y
+    def empty: S3ObjectListing = S3ObjectListing(Nil, Set.empty)
+  }
+}

--- a/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3ObjectListing.scala
+++ b/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3ObjectListing.scala
@@ -1,0 +1,7 @@
+package com.rewardsnetwork.pureaws.s3
+
+/** A listing of S3 objects and all common prefixes between them.
+  * A "common prefix" in this case is any delimited part of an S3 object key that has no data, and acts like a directory.
+  * For example if you have a key `foo/bar/baz` then `foo/bar` would be a common prefix, as there is no data at that key.
+  */
+final case class S3ObjectListing(objects: List[S3ObjectInfo], commonPrefixes: List[String])

--- a/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/SimpleS3Client.scala
+++ b/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/SimpleS3Client.scala
@@ -6,7 +6,8 @@ import software.amazon.awssdk.regions.Region
 
 /** An amalgamation of all available S3 algebras in one client. */
 sealed trait SimpleS3Client[F[_]] {
-  def ops: S3ObjectOps[F]
+  def bucketOps: S3BucketOps[F]
+  def objectOps: S3ObjectOps[F]
   def sink: S3Sink[F]
   def source: S3Source[F]
 }
@@ -17,7 +18,8 @@ object SimpleS3Client {
     * Gives you access to all available algebras for the S3 client in one place.
     */
   def apply[F[_]](client: PureS3Client[F])(implicit F: MonadError[F, Throwable]) = new SimpleS3Client[F] {
-    val ops = S3ObjectOps(client)
+    val bucketOps = S3BucketOps(client)
+    val objectOps = S3ObjectOps(client)
     val sink = S3Sink(client)
     val source = S3Source(client)
   }


### PR DESCRIPTION
This PR enables the following S3 enhancements:

* `S3BucketOps` for creating/listing/deleting buckets
* `S3ObjectOps` can now list objects
* `s3-testing` now supports the concept of buckets, and can mimic the S3 API as far as determining common prefixes ("folders", or sub-keys with no data in them)

Includes a breaking change in `SimpleS3Client` as the `ops` member needed to have its name changed.