### PR TITLE
"In" constructors, for separate effects

### DIFF
--- a/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/PureS3Client.scala
+++ b/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/PureS3Client.scala
@@ -253,6 +253,19 @@ object PureS3Client {
   def sync[F[_]: Sync: ContextShift](blocker: Blocker, awsRegion: Region): Resource[F, PureS3Client[F]] =
     S3ClientBackend.sync[F](blocker, awsRegion)().map(apply[F](blocker, _))
 
+  /** Creates a `PureS3Client` using a synchronous backend with default settings.
+    * This variant allows for creating the client with a different effect type than the `Resource` it is provided in.
+    *
+    * @param blocker A Cats Effect `Blocker`.
+    * @param awsRegion The AWS region you are operating in.
+    * @return A `Resource` containing a `PureS3Client` using a synchronous backend.
+    */
+  def syncIn[F[_]: Sync: ContextShift, G[_]: Sync: ContextShift](
+      blocker: Blocker,
+      awsRegion: Region
+  ): Resource[F, PureS3Client[G]] =
+    S3ClientBackend.sync[F](blocker, awsRegion)().map(apply[G](blocker, _))
+
   /** Creates a `PureS3Client` using an asynchronous backend with default settings.
     *
     * @param blocker A Cats Effect `Blocker`.
@@ -261,4 +274,17 @@ object PureS3Client {
     */
   def async[F[_]: ConcurrentEffect: ContextShift](blocker: Blocker, awsRegion: Region): Resource[F, PureS3Client[F]] =
     S3ClientBackend.async[F](blocker, awsRegion)().map(apply[F])
+
+  /** Creates a `PureS3Client` using an asynchronous backend with default settings.
+    * This variant allows for creating the client with a different effect type than the `Resource` it is provided in.
+    *
+    * @param blocker A Cats Effect `Blocker`.
+    * @param awsRegion The AWS region you are operating in.
+    * @return A `Resource` containing a `PureS3Client` using an asynchronous backend.
+    */
+  def asyncIn[F[_]: Sync: ContextShift, G[_]: ConcurrentEffect: ContextShift](
+      blocker: Blocker,
+      awsRegion: Region
+  ): Resource[F, PureS3Client[G]] =
+    S3ClientBackend.async[F](blocker, awsRegion)().map(apply[G])
 }

--- a/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3BucketOps.scala
+++ b/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3BucketOps.scala
@@ -1,8 +1,10 @@
 package com.rewardsnetwork.pureaws.s3
 
 import cats.Functor
+import cats.effect._
 import cats.implicits._
 import com.rewardsnetwork.pureaws.s3.S3BucketPermission._
+import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.model._
 
 import scala.jdk.CollectionConverters._
@@ -78,4 +80,48 @@ object S3BucketOps {
         .map(_.map(bucket => S3BucketInfo(bucket.name, bucket.creationDate)))
 
   }
+
+  /** Constructs an `S3BucketOps` using an underlying synchronous client backend.
+    *
+    * @param blocker A Cats Effect `Blocker`.
+    * @param awsRegion The AWS region you are operating in.
+    * @return An `S3BucketOps` instance using a synchronous backend.
+    */
+  def sync[F[_]: Sync: ContextShift](blocker: Blocker, awsRegion: Region): Resource[F, S3BucketOps[F]] =
+    PureS3Client.sync[F](blocker, awsRegion).map(apply[F])
+
+  /** Constructs an `S3BucketOps` using an underlying synchronous client backend.
+    * This variant allows for creating the client with a different effect type than the `Resource` it is provided in.
+    *
+    * @param blocker A Cats Effect `Blocker`.
+    * @param awsRegion The AWS region you are operating in.
+    * @return An `S3BucketOps` instance using a synchronous backend.
+    */
+  def syncIn[F[_]: Sync: ContextShift, G[_]: Sync: ContextShift](
+      blocker: Blocker,
+      awsRegion: Region
+  ): Resource[F, S3BucketOps[G]] =
+    PureS3Client.syncIn[F, G](blocker, awsRegion).map(apply[G])
+
+  /** Constructs an `S3BucketOps` using an underlying asynchronous client backend.
+    *
+    * @param blocker A Cats Effect `Blocker`.
+    * @param awsRegion The AWS region you are operating in.
+    * @return An `S3BucketOps` instance using an asynchronous backend.
+    */
+  def async[F[_]: ConcurrentEffect: ContextShift](blocker: Blocker, awsRegion: Region): Resource[F, S3BucketOps[F]] =
+    PureS3Client.async[F](blocker, awsRegion).map(apply[F])
+
+  /** Constructs an `S3BucketOps` using an underlying asynchronous client backend.
+    * This variant allows for creating the client with a different effect type than the `Resource` it is provided in.
+    *
+    * @param blocker A Cats Effect `Blocker`.
+    * @param awsRegion The AWS region you are operating in.
+    * @return An `S3BucketOps` instance using an asynchronous backend.
+    */
+  def asyncIn[F[_]: Sync: ContextShift, G[_]: ConcurrentEffect: ContextShift](
+      blocker: Blocker,
+      awsRegion: Region
+  ): Resource[F, S3BucketOps[G]] =
+    PureS3Client.asyncIn[F, G](blocker, awsRegion).map(apply[G])
 }

--- a/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3ObjectOps.scala
+++ b/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3ObjectOps.scala
@@ -159,8 +159,21 @@ object S3ObjectOps {
     * @param awsRegion The AWS region you are operating in.
     * @return An `S3ObjectOps` instance using a synchronous backend.
     */
-  def sync[F[_]: Sync: ContextShift](blocker: Blocker, awsRegion: Region) =
+  def sync[F[_]: Sync: ContextShift](blocker: Blocker, awsRegion: Region): Resource[F, S3ObjectOps[F]] =
     PureS3Client.sync[F](blocker, awsRegion).map(apply[F])
+
+  /** Constructs an `S3ObjectOps` using an underlying synchronous client backend.
+    * This variant allows for creating the client with a different effect type than the `Resource` it is provided in.
+    *
+    * @param blocker A Cats Effect `Blocker`.
+    * @param awsRegion The AWS region you are operating in.
+    * @return An `S3ObjectOps` instance using a synchronous backend.
+    */
+  def syncIn[F[_]: Sync: ContextShift, G[_]: Sync: ContextShift](
+      blocker: Blocker,
+      awsRegion: Region
+  ): Resource[F, S3ObjectOps[G]] =
+    PureS3Client.syncIn[F, G](blocker, awsRegion).map(apply[G])
 
   /** Constructs an `S3ObjectOps` using an underlying asynchronous client backend.
     *
@@ -168,6 +181,19 @@ object S3ObjectOps {
     * @param awsRegion The AWS region you are operating in.
     * @return An `S3ObjectOps` instance using an asynchronous backend.
     */
-  def async[F[_]: ConcurrentEffect: ContextShift](blocker: Blocker, awsRegion: Region) =
+  def async[F[_]: ConcurrentEffect: ContextShift](blocker: Blocker, awsRegion: Region): Resource[F, S3ObjectOps[F]] =
     PureS3Client.async[F](blocker, awsRegion).map(apply[F])
+
+  /** Constructs an `S3ObjectOps` using an underlying asynchronous client backend.
+    * This variant allows for creating the client with a different effect type than the `Resource` it is provided in.
+    *
+    * @param blocker A Cats Effect `Blocker`.
+    * @param awsRegion The AWS region you are operating in.
+    * @return An `S3ObjectOps` instance using an asynchronous backend.
+    */
+  def asyncIn[F[_]: Sync: ContextShift, G[_]: ConcurrentEffect: ContextShift](
+      blocker: Blocker,
+      awsRegion: Region
+  ): Resource[F, S3ObjectOps[G]] =
+    PureS3Client.asyncIn[F, G](blocker, awsRegion).map(apply[G])
 }

--- a/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3Sink.scala
+++ b/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3Sink.scala
@@ -160,8 +160,21 @@ object S3Sink {
     * @param awsRegion The AWS region you are operating in.
     * @return An `S3Sink` instance using a synchronous backend.
     */
-  def sync[F[_]: Sync: ContextShift](blocker: Blocker, awsRegion: Region) =
+  def sync[F[_]: Sync: ContextShift](blocker: Blocker, awsRegion: Region): Resource[F, S3Sink[F]] =
     PureS3Client.sync[F](blocker, awsRegion).map(apply[F])
+
+  /** Constructs an `S3Sink` using an underlying synchronous client backend.
+    * This variant allows for creating the client with a different effect type than the `Resource` it is provided in.
+    *
+    * @param blocker A Cats Effect `Blocker`.
+    * @param awsRegion The AWS region you are operating in.
+    * @return An `S3Sink` instance using a synchronous backend.
+    */
+  def syncIn[F[_]: Sync: ContextShift, G[_]: Sync: ContextShift](
+      blocker: Blocker,
+      awsRegion: Region
+  ): Resource[F, S3Sink[G]] =
+    PureS3Client.syncIn[F, G](blocker, awsRegion).map(apply[G])
 
   /** Constructs an `S3Sink` using an underlying asynchronous client backend.
     *
@@ -169,6 +182,19 @@ object S3Sink {
     * @param awsRegion The AWS region you are operating in.
     * @return An `S3Sink` instance using an asynchronous backend.
     */
-  def async[F[_]: ConcurrentEffect: ContextShift](blocker: Blocker, awsRegion: Region) =
+  def async[F[_]: ConcurrentEffect: ContextShift](blocker: Blocker, awsRegion: Region): Resource[F, S3Sink[F]] =
     PureS3Client.async[F](blocker, awsRegion).map(apply[F])
+
+  /** Constructs an `S3Sink` using an underlying asynchronous client backend.
+    * This variant allows for creating the client with a different effect type than the `Resource` it is provided in.
+    *
+    * @param blocker A Cats Effect `Blocker`.
+    * @param awsRegion The AWS region you are operating in.
+    * @return An `S3Sink` instance using an asynchronous backend.
+    */
+  def asyncIn[F[_]: Sync: ContextShift, G[_]: ConcurrentEffect: ContextShift](
+      blocker: Blocker,
+      awsRegion: Region
+  ): Resource[F, S3Sink[G]] =
+    PureS3Client.asyncIn[F, G](blocker, awsRegion).map(apply[G])
 }

--- a/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3Source.scala
+++ b/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/S3Source.scala
@@ -76,8 +76,21 @@ object S3Source {
     * @param awsRegion The AWS region you are operating in.
     * @return An `S3Source` instance using a synchronous backend.
     */
-  def sync[F[_]: Sync: ContextShift](blocker: Blocker, awsRegion: Region) =
+  def sync[F[_]: Sync: ContextShift](blocker: Blocker, awsRegion: Region): Resource[F, S3Source[F]] =
     PureS3Client.sync[F](blocker, awsRegion).map(apply[F])
+
+  /** Constructs an `S3Source` using an underlying synchronous client backend.
+    * This variant allows for creating the client with a different effect type than the `Resource` it is provided in.
+    *
+    * @param blocker A Cats Effect `Blocker`.
+    * @param awsRegion The AWS region you are operating in.
+    * @return An `S3Source` instance using a synchronous backend.
+    */
+  def syncIn[F[_]: Sync: ContextShift, G[_]: Sync: ContextShift](
+      blocker: Blocker,
+      awsRegion: Region
+  ): Resource[F, S3Source[G]] =
+    PureS3Client.syncIn[F, G](blocker, awsRegion).map(apply[G])
 
   /** Constructs an `S3Source` using an underlying asynchronous client backend.
     *
@@ -85,6 +98,19 @@ object S3Source {
     * @param awsRegion The AWS region you are operating in.
     * @return An `S3Source` instance using an asynchronous backend.
     */
-  def async[F[_]: ConcurrentEffect: ContextShift](blocker: Blocker, awsRegion: Region) =
+  def async[F[_]: ConcurrentEffect: ContextShift](blocker: Blocker, awsRegion: Region): Resource[F, S3Source[F]] =
     PureS3Client.async[F](blocker, awsRegion).map(apply[F])
+
+  /** Constructs an `S3Source` using an underlying asynchronous client backend.
+    * This variant allows for creating the client with a different effect type than the `Resource` it is provided in.
+    *
+    * @param blocker A Cats Effect `Blocker`.
+    * @param awsRegion The AWS region you are operating in.
+    * @return An `S3Source` instance using an asynchronous backend.
+    */
+  def asyncIn[F[_]: Sync: ContextShift, G[_]: ConcurrentEffect: ContextShift](
+      blocker: Blocker,
+      awsRegion: Region
+  ): Resource[F, S3Source[G]] =
+    PureS3Client.asyncIn[F, G](blocker, awsRegion).map(apply[G])
 }

--- a/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/SimpleS3Client.scala
+++ b/modules/s3/src/main/scala/com/rewardsnetwork/pureaws/s3/SimpleS3Client.scala
@@ -30,8 +30,21 @@ object SimpleS3Client {
     * @param awsRegion The AWS region you are operating in.
     * @return A `SimpleS3Client` instance using a synchronous backend.
     */
-  def sync[F[_]: Sync: ContextShift](blocker: Blocker, awsRegion: Region) =
+  def sync[F[_]: Sync: ContextShift](blocker: Blocker, awsRegion: Region): Resource[F, SimpleS3Client[F]] =
     PureS3Client.sync[F](blocker, awsRegion).map(apply[F])
+
+  /** Constructs a `SimpleS3Client` using an underlying synchronous client backend.
+    * This variant allows for creating the client with a different effect type than the `Resource` it is provided in.
+    *
+    * @param blocker A Cats Effect `Blocker`.
+    * @param awsRegion The AWS region you are operating in.
+    * @return A `SimpleS3Client` instance using a synchronous backend.
+    */
+  def syncIn[F[_]: Sync: ContextShift, G[_]: Sync: ContextShift](
+      blocker: Blocker,
+      awsRegion: Region
+  ): Resource[F, SimpleS3Client[G]] =
+    PureS3Client.syncIn[F, G](blocker, awsRegion).map(apply[G])
 
   /** Constructs a `SimpleS3Client` using an underlying asynchronous client backend.
     *
@@ -39,6 +52,19 @@ object SimpleS3Client {
     * @param awsRegion The AWS region you are operating in.
     * @return A `SimpleS3Client` instance using an asynchronous backend.
     */
-  def async[F[_]: ConcurrentEffect: ContextShift](blocker: Blocker, awsRegion: Region) =
+  def async[F[_]: ConcurrentEffect: ContextShift](blocker: Blocker, awsRegion: Region): Resource[F, SimpleS3Client[F]] =
     PureS3Client.async[F](blocker, awsRegion).map(apply[F])
+
+  /** Constructs a `SimpleS3Client` using an underlying asynchronous client backend.
+    * This variant allows for creating the client with a different effect type than the `Resource` it is provided in.
+    *
+    * @param blocker A Cats Effect `Blocker`.
+    * @param awsRegion The AWS region you are operating in.
+    * @return A `SimpleS3Client` instance using an asynchronous backend.
+    */
+  def asyncIn[F[_]: Sync: ContextShift, G[_]: ConcurrentEffect: ContextShift](
+      blocker: Blocker,
+      awsRegion: Region
+  ): Resource[F, SimpleS3Client[G]] =
+    PureS3Client.asyncIn[F, G](blocker, awsRegion).map(apply[G])
 }

--- a/modules/sqs/src/main/scala/com/rewardsnetwork/pureaws/sqs/PureSqsClient.scala
+++ b/modules/sqs/src/main/scala/com/rewardsnetwork/pureaws/sqs/PureSqsClient.scala
@@ -142,8 +142,21 @@ object PureSqsClient {
     * @param awsRegion The AWS region you are operating in.
     * @return A `Resource` containing a `PureSqsClient` using a synchronous backend.
     */
-  def sync[F[_]: Sync: ContextShift](blocker: Blocker, awsRegion: Region) =
+  def sync[F[_]: Sync: ContextShift](blocker: Blocker, awsRegion: Region): Resource[F, PureSqsClient[F]] =
     SqsClientBackend.sync[F](blocker, awsRegion)().map(apply[F](blocker, _))
+
+  /** Creates a `PureSqsClient` using a synchronous backend with default settings.
+    * This variant allows for creating the client with a different effect type than the `Resource` it is provided in.
+    *
+    * @param blocker A Cats Effect `Blocker`.
+    * @param awsRegion The AWS region you are operating in.
+    * @return A `Resource` containing a `PureSqsClient` using a synchronous backend.
+    */
+  def syncIn[F[_]: Sync: ContextShift, G[_]: Sync: ContextShift](
+      blocker: Blocker,
+      awsRegion: Region
+  ): Resource[F, PureSqsClient[G]] =
+    SqsClientBackend.sync[F](blocker, awsRegion)().map(apply[G](blocker, _))
 
   /** Creates a `PureSqsClient` using an asynchronous backend with default settings.
     *
@@ -151,6 +164,19 @@ object PureSqsClient {
     * @param awsRegion The AWS region you are operating in.
     * @return A `Resource` containing a `PureSqsClient` using an asynchronous backend.
     */
-  def async[F[_]: Async: ContextShift](blocker: Blocker, awsRegion: Region) =
+  def async[F[_]: Async: ContextShift](blocker: Blocker, awsRegion: Region): Resource[F, PureSqsClient[F]] =
     SqsClientBackend.async[F](blocker, awsRegion)().map(apply[F])
+
+  /** Creates a `PureSqsClient` using an asynchronous backend with default settings.
+    * This variant allows for creating the client with a different effect type than the `Resource` it is provided in.
+    *
+    * @param blocker A Cats Effect `Blocker`.
+    * @param awsRegion The AWS region you are operating in.
+    * @return A `Resource` containing a `PureSqsClient` using an asynchronous backend.
+    */
+  def asyncIn[F[_]: Sync: ContextShift, G[_]: Async: ContextShift](
+      blocker: Blocker,
+      awsRegion: Region
+  ): Resource[F, PureSqsClient[G]] =
+    SqsClientBackend.async[F](blocker, awsRegion)().map(apply[G])
 }

--- a/modules/sqs/src/main/scala/com/rewardsnetwork/pureaws/sqs/SimpleSqsClient.scala
+++ b/modules/sqs/src/main/scala/com/rewardsnetwork/pureaws/sqs/SimpleSqsClient.scala
@@ -146,8 +146,21 @@ object SimpleSqsClient {
     * @param awsRegion The AWS region you are operating in.
     * @return An `SimpleSqsClient` instance using a synchronous backend.
     */
-  def sync[F[_]: Sync: ContextShift](blocker: Blocker, awsRegion: Region) =
+  def sync[F[_]: Sync: ContextShift](blocker: Blocker, awsRegion: Region): Resource[F, SimpleSqsClient[F]] =
     PureSqsClient.sync[F](blocker, awsRegion).map(apply[F])
+
+  /** Constructs a `SimpleSqsClient` using an underlying synchronous client backend.
+    * This variant allows for creating the client with a different effect type than the `Resource` it is provided in.
+    *
+    * @param blocker A Cats Effect `Blocker`.
+    * @param awsRegion The AWS region you are operating in.
+    * @return An `SimpleSqsClient` instance using a synchronous backend.
+    */
+  def syncIn[F[_]: Sync: ContextShift, G[_]: Sync: ContextShift](
+      blocker: Blocker,
+      awsRegion: Region
+  ): Resource[F, SimpleSqsClient[G]] =
+    PureSqsClient.syncIn[F, G](blocker, awsRegion).map(apply[G])
 
   /** Constructs a `SimpleSqsClient` using an underlying asynchronous client backend.
     *
@@ -155,6 +168,19 @@ object SimpleSqsClient {
     * @param awsRegion The AWS region you are operating in.
     * @return A `SimpleSqsClient` instance using an asynchronous backend.
     */
-  def async[F[_]: Async: ContextShift](blocker: Blocker, awsRegion: Region) =
+  def async[F[_]: Async: ContextShift](blocker: Blocker, awsRegion: Region): Resource[F, SimpleSqsClient[F]] =
     PureSqsClient.async[F](blocker, awsRegion).map(apply[F])
+
+  /** Constructs a `SimpleSqsClient` using an underlying asynchronous client backend.
+    * This variant allows for creating the client with a different effect type than the `Resource` it is provided in.
+    *
+    * @param blocker A Cats Effect `Blocker`.
+    * @param awsRegion The AWS region you are operating in.
+    * @return A `SimpleSqsClient` instance using an asynchronous backend.
+    */
+  def asyncIn[F[_]: Sync: ContextShift, G[_]: Async: ContextShift](
+      blocker: Blocker,
+      awsRegion: Region
+  ): Resource[F, SimpleSqsClient[G]] =
+    PureSqsClient.asyncIn[F, G](blocker, awsRegion).map(apply[G])
 }


### PR DESCRIPTION
Added a separate set of constructors for each client for when you want to use different effects for the `Resource` and the underlying client. A good example of when you would want to use this is, if you have a less powerful effect that forms `Sync` but does not form `ConcurrentEffect`, such as `Kleisli[F, A, B]` (which you cannot have an `Effect` for, because how would you provide a value for it to be able to run?) or `ConnectionIO` from Doobie.

Also adds constructors for `S3BucketOps` which I forgot to include in the last PR (whoops)