### PR TITLE
Add support for SQS message with custom message attributes

### DIFF
--- a/modules/sqs-refined/src/main/scala/com/rewardsnetwork/pureaws/sqs/refined/RefinedMessage.scala
+++ b/modules/sqs-refined/src/main/scala/com/rewardsnetwork/pureaws/sqs/refined/RefinedMessage.scala
@@ -1,7 +1,6 @@
 package com.rewardsnetwork.pureaws.sqs.refined
 
 import com.rewardsnetwork.pureaws.sqs._
-import software.amazon.awssdk.services.sqs.model.MessageAttributeValue
 
 /** An `SqsMessage` that also contains a `RefinedReceiptHandle` */
 final case class RefinedMessage[F[_]](
@@ -16,10 +15,3 @@ final case class RefinedMessageWithAttributes[F[_]](
     attributes: MessageAttributes
 ) extends BaseSqsMessage[F, VisibilityTimeout]
     with WithAttributes
-
-/** An `SqsMessageWithCustomAttributes` that also contains a `RefinedReceiptHandle` */
-final case class RefinedMessageWithCustomAttributes[F[_]](
-    body: String,
-    receiptHandle: RefinedReceiptHandle[F],
-    attributes: Map[String, MessageAttributeValue]
-) extends BaseSqsMessage[F, VisibilityTimeout]

--- a/modules/sqs-refined/src/main/scala/com/rewardsnetwork/pureaws/sqs/refined/RefinedMessage.scala
+++ b/modules/sqs-refined/src/main/scala/com/rewardsnetwork/pureaws/sqs/refined/RefinedMessage.scala
@@ -1,6 +1,7 @@
 package com.rewardsnetwork.pureaws.sqs.refined
 
 import com.rewardsnetwork.pureaws.sqs._
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue
 
 /** An `SqsMessage` that also contains a `RefinedReceiptHandle` */
 final case class RefinedMessage[F[_]](
@@ -15,3 +16,10 @@ final case class RefinedMessageWithAttributes[F[_]](
     attributes: MessageAttributes
 ) extends BaseSqsMessage[F, VisibilityTimeout]
     with WithAttributes
+
+/** An `SqsMessageWithCustomAttributes` that also contains a `RefinedReceiptHandle` */
+final case class RefinedMessageWithCustomAttributes[F[_]](
+    body: String,
+    receiptHandle: RefinedReceiptHandle[F],
+    attributes: Map[String, MessageAttributeValue]
+) extends BaseSqsMessage[F, VisibilityTimeout]

--- a/modules/sqs-refined/src/main/scala/com/rewardsnetwork/pureaws/sqs/refined/RefinedSqsClient.scala
+++ b/modules/sqs-refined/src/main/scala/com/rewardsnetwork/pureaws/sqs/refined/RefinedSqsClient.scala
@@ -36,6 +36,15 @@ trait RefinedSqsClient[F[_]] {
   /** Delete a message given you have its receipt handle. */
   def deleteMessage(receiptHandle: RefinedReceiptHandle[F]): F[Unit]
 
+  /** Send a message to an SQS queue. Message delay is determined by the queue settings.
+    * @return
+    *   The message ID string of the sent message.
+    */
+  def sendMessage(
+      queueUrl: String,
+      messageBody: String
+  ): F[String]
+
   /** Send a message with attributes to an SQS queue. Message delay is determined by the queue settings.
     * @return
     *   The message ID string of the sent message.
@@ -44,6 +53,16 @@ trait RefinedSqsClient[F[_]] {
       queueUrl: String,
       messageBody: String,
       messageAttributes: Map[String, MessageAttributeValue]
+  ): F[String]
+
+  /** Sends a message to an SQS queue. Allows specifying the seconds to delay the message.
+    * @return
+    *   The message ID string of the sent message.
+    */
+  def sendMessage(
+      queueUrl: String,
+      messageBody: String,
+      delaySeconds: Int Refined DelaySeconds
   ): F[String]
 
   /** Sends a message with attributes to an SQS queue. Allows specifying the seconds to delay the message.
@@ -112,8 +131,14 @@ object RefinedSqsClient {
       def deleteMessage(receiptHandle: RefinedReceiptHandle[F]): F[Unit] =
         simpleClient.deleteMessage(receiptHandle.rawReceiptHandle, receiptHandle.queueUrl)
 
+      def sendMessage(queueUrl: String, messageBody: String): F[String] =
+        simpleClient.sendMessage(queueUrl, messageBody)
+
       def sendMessage(queueUrl: String, messageBody: String, messageAttributes: Map[String, MessageAttributeValue]): F[String] =
         simpleClient.sendMessage(queueUrl, messageBody, messageAttributes)
+
+      def sendMessage(queueUrl: String, messageBody: String, delaySeconds: Int Refined DelaySeconds): F[String] =
+        simpleClient.sendMessage(queueUrl, messageBody, delaySeconds.value)
 
       def sendMessage(queueUrl: String, messageBody: String, delaySeconds: Int Refined DelaySeconds, messageAttributes: Map[String, MessageAttributeValue]): F[String] =
         simpleClient.sendMessage(queueUrl, messageBody, delaySeconds.value, messageAttributes)

--- a/modules/sqs/src/main/scala/com/rewardsnetwork/pureaws/sqs/MessageAttributes.scala
+++ b/modules/sqs/src/main/scala/com/rewardsnetwork/pureaws/sqs/MessageAttributes.scala
@@ -1,7 +1,7 @@
 package com.rewardsnetwork.pureaws.sqs
 
 import com.rewardsnetwork.pureaws.compat.Conversions._
-import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName
+import software.amazon.awssdk.services.sqs.model.{MessageAttributeValue, MessageSystemAttributeName}
 
 final case class MessageAttributes(
     approximateReceiveCount: Option[Int],
@@ -10,11 +10,12 @@ final case class MessageAttributes(
     messageGroupId: Option[String],
     senderId: Option[String],
     sentTimestampEpochMillis: Option[Long],
-    sequenceNumber: Option[Long]
+    sequenceNumber: Option[Long],
+    other: Map[String, MessageAttributeValue]
 )
 
 object MessageAttributes {
-  def fromMap(m: Map[MessageSystemAttributeName, String]): MessageAttributes = {
+  def fromMap(m: Map[MessageSystemAttributeName, String], other: Map[String, MessageAttributeValue]): MessageAttributes = {
     import MessageSystemAttributeName._
     val approxReceiveCount = m.get(APPROXIMATE_RECEIVE_COUNT).flatMap(toIntOption)
     val approxFirstReceiveTimestamp = m.get(APPROXIMATE_FIRST_RECEIVE_TIMESTAMP).flatMap(toLongOption)
@@ -31,7 +32,8 @@ object MessageAttributes {
       groupId,
       senderId,
       sentTimestamp,
-      sequenceNumber
+      sequenceNumber,
+      other
     )
   }
 }

--- a/modules/sqs/src/main/scala/com/rewardsnetwork/pureaws/sqs/SqsMessage.scala
+++ b/modules/sqs/src/main/scala/com/rewardsnetwork/pureaws/sqs/SqsMessage.scala
@@ -4,6 +4,7 @@ import cats._
 import cats.syntax.all._
 import cats.effect.Temporal
 import fs2.Stream
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -87,3 +88,10 @@ final case class SqsMessageWithAttributes[F[_]](
     attributes: MessageAttributes
 ) extends BaseSqsMessage[F, Int]
     with WithAttributes
+
+/** A message received from AWS SQS, with customer message attributes. */
+final case class SqsMessageWithCustomAttributes[F[_]](
+    body: String,
+    receiptHandle: ReceiptHandle[F],
+    attributes: Map[String, MessageAttributeValue]
+) extends BaseSqsMessage[F, Int]

--- a/modules/sqs/src/main/scala/com/rewardsnetwork/pureaws/sqs/SqsMessage.scala
+++ b/modules/sqs/src/main/scala/com/rewardsnetwork/pureaws/sqs/SqsMessage.scala
@@ -4,7 +4,6 @@ import cats._
 import cats.syntax.all._
 import cats.effect.Temporal
 import fs2.Stream
-import software.amazon.awssdk.services.sqs.model.MessageAttributeValue
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -88,10 +87,3 @@ final case class SqsMessageWithAttributes[F[_]](
     attributes: MessageAttributes
 ) extends BaseSqsMessage[F, Int]
     with WithAttributes
-
-/** A message received from AWS SQS, with customer message attributes. */
-final case class SqsMessageWithCustomAttributes[F[_]](
-    body: String,
-    receiptHandle: ReceiptHandle[F],
-    attributes: Map[String, MessageAttributeValue]
-) extends BaseSqsMessage[F, Int]


### PR DESCRIPTION
Hello :blush:

I found that this amazing library doesn't support sending and receiving SQS messages with [custom message attributes](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-metadata.html#sqs-message-attributes).

My changes:

- Two new subtypes of `BaseSqsMessage`: `SqsMessageWithCustomAttributes` and `RefinedMessageWithCustomAttributes` with scala Map as message attributes
- These new types are used in `SimpleSqsClient.scala` and `RefinedSqsClient.scala` to receive messages and send messages